### PR TITLE
최대년도 비교식을 변경.

### DIFF
--- a/mod_share_movie.py
+++ b/mod_share_movie.py
@@ -120,7 +120,7 @@ class ModuleShareMovie(PluginModuleBase):
                 cond_year = P.ModelSetting.get(f'{self.name}_blacklist_year')
                 if cond_year != '' and '-' in cond_year:
                     tmp = cond_year.split('-')
-                    if int(tmp[0]) <= item.year and item.year >= int(tmp[1]):
+                    if int(tmp[0]) <= item.year and item.year <= int(tmp[1]):
                         return False
                 return True
 
@@ -145,7 +145,7 @@ class ModuleShareMovie(PluginModuleBase):
                 cond_year = P.ModelSetting.get(f'{self.name}_whitelist_year')
                 if cond_year != '' and '-' in cond_year:
                     tmp = cond_year.split('-')
-                    if int(tmp[0]) <= item.year and item.year >= int(tmp[1]):
+                    if int(tmp[0]) <= item.year and item.year <= int(tmp[1]):
                         return True
                 return flag_download
 


### PR DESCRIPTION
화이트리스트와 블랙리스트의 최대년도 비교식이 최소년도처럼 설정되어 있어서 수정이 필요해 보입니다.

-----

(좀 더 변경 사항의 구분이 쉽도록 whitespace 제거를 하지 않고 다시 request 합니다.)